### PR TITLE
fix: read more button alt text doesn't appear

### DIFF
--- a/inc/content_lg.php
+++ b/inc/content_lg.php
@@ -120,8 +120,8 @@ while( have_rows('content_sections') ): the_row();
 								<?php if ( $link['block_link']!='' ){?>
 									<div class="card-footer bg-transparent border-0">
 											<a href="<?php echo $link['block_link'] ?>" target="<?php if ( get_sub_field( "callout_open_new_tab" ) ) { echo "_blank"; }?>" class="btn btn-ghost <?php echo get_field( "background_style" )=='bg-gradient-h'?'white':'blue'; ?>">			
-											<?php if ( get_sub_field( "callout_block_link_text" )!='' ){ ?>
-												<strong><?php echo get_sub_field( "callout_block_link_text" )?></strong>
+											<?php if ( $link['callout_block_link_text'] ){ ?>
+												<strong><?php echo $link['callout_block_link_text'] ?></strong>
 											<?php } else {  ?>
 											<strong><?php _e( 'Read more', 'html5blank' ); }?></strong>
 										</a>


### PR DESCRIPTION
This PR fixes an issue where the provided button text was not shown on the button, default text was displayed instead.