### PR TITLE
fix: checkbox names need to be unique

### DIFF
--- a/inc/newsletterform.php
+++ b/inc/newsletterform.php
@@ -9,19 +9,19 @@
 				<div id="warningDiv"></div>
 			</legend>
 			<div class="checkbox">
-				<input type="checkbox" id="MNO-newsletter" name="list_ids" value="dd99ff3d-5d3e-4824-af92-bdedb1ee9f05" />
+				<input type="checkbox" id="MNO-newsletter" name="list_mno" value="dd99ff3d-5d3e-4824-af92-bdedb1ee9f05" />
 				<label for="MNO-newsletter">MNO newsletter</label>
 			</div>
 			<div class="checkbox">
-				<input type="checkbox" id="Community-newsletter" name="list_ids" value="398bdea0-cf30-48af-8d40-d9b42ec623a3" />
+				<input type="checkbox" id="Community-newsletter" name="list_community" value="398bdea0-cf30-48af-8d40-d9b42ec623a3" />
 				<label for="Community-newsletter">Community Members newsletter</label>
 			</div>
 			<div class="checkbox">
-				<input type="checkbox" id="Developer newsletter" name="list_ids" value="828e94c9-bd4a-4550-b67d-91c4f5d0a348" />
+				<input type="checkbox" id="Developer newsletter" name="list_dev" value="828e94c9-bd4a-4550-b67d-91c4f5d0a348" />
 				<label for="Developer-newsletter">Developer newsletter</label>
 			</div>
 			<div class="checkbox">
-				<input type="checkbox" id="Investor-newsletter" name="list_ids" value="0a9faa61-98db-4726-8362-ef2f0f9de135" />
+				<input type="checkbox" id="Investor-newsletter" name="list_investor" value="0a9faa61-98db-4726-8362-ef2f0f9de135" />
 				<label for="Investor-newsletter">Investor Newsletter</label>
 			</div>
 		</fieldset>


### PR DESCRIPTION
Different checkboxes need unique names otherwise they overwrite each other, note that while it can be done (ie nothing in HTML explicitly **forbids** it) most backends need hacky workarounds, see this one for PHP: https://stackoverflow.com/questions/16552680/several-checkboxes-sharing-the-same-name

This PR simply separates them out into different names so the backend can deal with it