### PR TITLE
Fix broken header layout on desktop viewports

### DIFF
--- a/assets/dash.css
+++ b/assets/dash.css
@@ -8492,3 +8492,36 @@ footer .footer-top {
     width: 150px;
   }
 }
+
+/* ============================================
+   Header fix: ensure desktop layout works
+   regardless of Bootstrap utility classes
+   ============================================ */
+@media (min-width: 992px) {
+  /* Hide hamburger menu on desktop */
+  .header .d-lg-none {
+    display: none !important;
+  }
+
+  /* Ensure proper column sizing for header */
+  .header .col-lg-2 {
+    flex: 0 0 16.666667%;
+    max-width: 16.666667%;
+  }
+
+  .header .col-lg-10 {
+    flex: 0 0 83.333333%;
+    max-width: 83.333333%;
+  }
+
+  /* Hide mobile-only Home links in dropdowns */
+  #navbar-main .navbar-item .dropdown .link.first.d-lg-none {
+    display: none !important;
+  }
+
+  /* Ensure header row uses flexbox layout */
+  .header .row {
+    display: flex;
+    flex-wrap: wrap;
+  }
+}

--- a/functions.php
+++ b/functions.php
@@ -149,7 +149,7 @@ function theme_styles()
     
     // Remove time() and replace with static version number after strophy finishes fixing CSS
 
-    wp_register_style('dashcss', get_template_directory_uri() . '/assets/dash.css', array(), '1.84', 'all');
+    wp_register_style('dashcss', get_template_directory_uri() . '/assets/dash.css', array(), '1.85', 'all');
     wp_enqueue_style('dashcss');
 
 }


### PR DESCRIPTION
## Summary
- The header navigation is broken on desktop: hamburger menu visible, extra "Home" link in dropdowns, and nav items mispositioned outside the header bar
- Root cause: Bootstrap responsive utility classes (`d-lg-none`, `col-lg-*`) are not being reliably applied, likely due to Cloudflare CSS optimization/caching
- Adds explicit `@media (min-width: 992px)` rules to `dash.css` that make the header layout self-sufficient

## Changes
Appends a targeted CSS block to `assets/dash.css` that:
1. Hides the hamburger menu container on desktop (`.header .d-lg-none`)
2. Sets correct flex column widths for the header grid (`.col-lg-2`, `.col-lg-10`)
3. Hides mobile-only "Home" links in dropdown menus
4. Ensures the header row uses flexbox layout

## Test plan
- [ ] Verify header renders correctly on desktop (≥992px): full-width white bar, no hamburger, nav items inside header
- [ ] Verify "Get Started" dropdown does NOT show "Home" as first item on desktop
- [ ] Verify mobile layout (< 992px) still works: hamburger visible, nav hidden until toggled
- [ ] Test across browsers (Chrome, Firefox, Safari)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved desktop header layout and spacing for larger screens: fixed header column sizing, flex-based header row, and hidden mobile navigation elements in desktop view for a cleaner navbar.
* **Chores**
  * Bumped stylesheet version to publish the layout updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->